### PR TITLE
Make compatible with Illuminate TransformsRequest

### DIFF
--- a/src/Http/Middleware/ConvertToSnakeCase.php
+++ b/src/Http/Middleware/ConvertToSnakeCase.php
@@ -28,7 +28,7 @@ class ConvertToSnakeCase extends TransformsRequest
      * @param  array $data
      * @return array
      */
-    protected function cleanArray(array $data)
+    protected function cleanArray(array $data, $keyPrefix = '')
     {
         $parameters = [];
 


### PR DESCRIPTION
Declaration of Flugg\Responder\Http\Middleware\ConvertToSnakeCase::cleanArray(array $data) should be compatible with Illuminate\Foundation\Http\Middleware\TransformsRequest::cleanArray(array $data, $keyPrefix = '')